### PR TITLE
Add CORS bypass for testing purposes

### DIFF
--- a/src/main/java/com/interview/vaccines/config/CorsConfiguration.java
+++ b/src/main/java/com/interview/vaccines/config/CorsConfiguration.java
@@ -1,0 +1,14 @@
+package com.interview.vaccines.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+// ???: (Kévin Dumanoir) 03/05/2021 Please NEVER set a such configuration for a production project !
+@Configuration
+public class CorsConfiguration implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedMethods("*");
+    }
+}


### PR DESCRIPTION
When accessing APIs from browser, CORS policy must be explicit or, for testing purposes, fully disabled.